### PR TITLE
allow for glue syntax in excel report sheet names

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Imports:
     base64enc (>= 0.1-3),
     cli (>= 3.6.1),
     dplyr (>= 1.1.2),
-    glue,
+    glue (>= 1.6.2),
     gt (>= 0.9.0),
     htmltools (>= 0.5.5),
     openxlsx (>= 4.2.5.2),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ URL: https://github.com/pages/pcctc/affirm/,
     https://pcctc.github.io/affirm/
 BugReports: https://github.com/pcctc/affirm/issues
 Depends: 
-    R (>= 4.1)
+    R (>= 4.2)
 Imports: 
     base64enc (>= 0.1-3),
     cli (>= 3.6.1),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,6 +21,7 @@ Imports:
     base64enc (>= 0.1-3),
     cli (>= 3.6.1),
     dplyr (>= 1.1.2),
+    glue,
     gt (>= 0.9.0),
     htmltools (>= 0.5.5),
     openxlsx (>= 4.2.5.2),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # affirm (development version)
 
+* Allow for glue syntax in excel report sheet names.
+
 * When no errors are found, return a data frame of zero rows instead of `NULL`.
 
 * No longer re-exporting `tibble()`, `as_tibble()`, `filter()`, `select()`, and `mutate()` from {dplyr}.

--- a/R/affirm_report.R
+++ b/R/affirm_report.R
@@ -8,6 +8,9 @@
 #' @param variable_labels logical indicating whether to add a row to exported
 #' data with the variable labels. If label does not exist, the variable name
 #' is printed. Default is `FALSE`
+#' @param sheet_name A string for sheet names in the excel report; the item name
+#' in curly brackets is replaced with the item value (see glue::glue). Item names
+#' accepted include: `id`, `label`, `priority`, `data_frames`, `columns`, `error_n`, `total_n`.
 #'
 #' @return gt table
 #' @name affirm_report
@@ -59,11 +62,16 @@ affirm_report_gt <- function(variable_labels = FALSE) {
 affirm_report_excel <- function(file, sheet_name = "{data_frames}{id}", variable_labels = FALSE, overwrite = TRUE) {
 
   # checking to make sure sheet name glue syntax has acceptable column names
-  sheet_name_cols <- unlist(strsplit(sheet_name, "[{}]"))
-  sheet_name_cols <- sheet_name_cols[sheet_name_cols != ""]
+  sheet_name_cols <- regmatches(sheet_name, gregexpr("\\{([^\\}]+)\\}", sheet_name))[[1]] |>
+    gsub("\\{|\\}", "", x = _)
+
+  # acceptable variables to pass through glue syntax for sheet names
   glue_accept <- c("id", "label", "priority", "data_frames", "columns", "error_n", "total_n")
+
+  # readable version for error messaging
+  glue_accept_str <- paste0("`", glue_accept, "`", collapse = ", ")
   if (any(!sheet_name_cols %in% glue_accept)){
-    stop(paste0("`sheet_name` glue syntax expects one of ", paste(glue_accept, collapse = ", ")))
+    stop(paste0("`sheet_name` glue syntax expects one of ", glue_accept_str))
   }
 
   df_report <-

--- a/R/affirm_report.R
+++ b/R/affirm_report.R
@@ -56,22 +56,31 @@ affirm_report_gt <- function(variable_labels = FALSE) {
 
 #' @rdname affirm_report
 #' @export
-affirm_report_excel <- function(file, variable_labels = FALSE, overwrite = TRUE) {
+affirm_report_excel <- function(file, sheet_name = "{data_frames}{id}", variable_labels = FALSE, overwrite = TRUE) {
+
+  # checking to make sure sheet name glue syntax has acceptable column names
+  sheet_name_cols <- unlist(strsplit(sheet_name, "[{}]"))
+  sheet_name_cols <- sheet_name_cols[sheet_name_cols != ""]
+  glue_accept <- c("id", "label", "priority", "data_frames", "columns", "error_n", "total_n")
+  if (any(!sheet_name_cols %in% glue_accept)){
+    stop(paste0("`sheet_name` glue syntax expects one of ", paste(glue_accept, collapse = ", ")))
+  }
+
   df_report <-
     affirm_report_raw_data(variable_labels = variable_labels) |>
     dplyr::filter(.data$error_n > 0L) |>
     dplyr::mutate(
-      label_no_specials = gsub(pattern = "[[:punct:]]", replacement = "", x = .data$label),
-      label_final =
-        ifelse(
-          is.na(.data$id),
-          .data$label_no_specials,
-          paste(.data$id, .data$label_no_specials)
-        )
+      label_final = glue::glue(sheet_name) |>
+        gsub(pattern = "[[:punct:]]", replacement = "", x = _)
     )
 
+  # checking to make sure sheet names are not too long
+  if (any(nchar(df_report$label_final) > 31)){
+    stop("At least one sheet name exceeds the allowed 31 characters.")
+  }
+
   df_report$data |>
-    stats::setNames(df_report$label_no_specials) |>
+    stats::setNames(df_report$label_final) |>
     openxlsx::write.xlsx(file = file, overwrite = overwrite, colNames = !variable_labels)
 }
 

--- a/man/affirm_report.Rd
+++ b/man/affirm_report.Rd
@@ -9,7 +9,12 @@
 \usage{
 affirm_report_gt(variable_labels = FALSE)
 
-affirm_report_excel(file, variable_labels = FALSE, overwrite = TRUE)
+affirm_report_excel(
+  file,
+  sheet_name = "{data_frames}{id}",
+  variable_labels = FALSE,
+  overwrite = TRUE
+)
 
 affirm_report_raw_data(variable_labels = FALSE)
 }
@@ -19,6 +24,10 @@ data with the variable labels. If label does not exist, the variable name
 is printed. Default is \code{FALSE}}
 
 \item{file}{A file path to save the xlsx file}
+
+\item{sheet_name}{A string for sheet names in the excel report; the item name
+in curly brackets is replaced with the item value (see glue::glue). Item names
+accepted include: \code{id}, \code{label}, \code{priority}, \code{data_frames}, \code{columns}, \code{error_n}, \code{total_n}.}
 
 \item{overwrite}{Overwrite existing file (Defaults to \code{TRUE} as with \code{write.table})}
 }

--- a/tests/testthat/test-affirm_report.R
+++ b/tests/testthat/test-affirm_report.R
@@ -76,26 +76,47 @@ test_that("affirm_report_excel() details", {
   attr(mtcars_modified$cyl, 'label') <- "Number of cylinders"
   attr(mtcars_modified$disp, 'label') <- "Displacement (cu.in.)"
 
-expect_error({
-  affirm_init(replace = TRUE)
-  options('affirm.id_cols' = "car")
-  affirm_true(
-    mtcars_modified,
-    label = "No. cylinders must be 4 or 6",
-    condition = cyl %in% c(4, 6),
-    id = 1,
-    data_frames = "mtcars"
+  expect_error({
+    affirm_init(replace = TRUE)
+    options('affirm.id_cols' = "car")
+    affirm_true(
+      mtcars_modified,
+      label = "No. cylinders must be 4 or 6",
+      condition = cyl %in% c(4, 6),
+      id = 1,
+      data_frames = "mtcars"
+    )
+    affirm_true(
+      mtcars_modified,
+      label = "mpg lt 33",
+      id = 2,
+      condition = mpg < 33,
+      data_frames = "mtcars"
+    );
+    affirm_report_excel(file = tempfile(fileext = ".xlsx"))},
+    NA
   )
-  affirm_true(
-    mtcars_modified,
-    label = "mpg lt 33",
-    id = 2,
-    condition = mpg < 33,
-    data_frames = "mtcars"
-  );
-  affirm_report_excel(file = tempfile(fileext = ".xlsx"))},
-  NA
-)
+
+  expect_error({
+    affirm_init(replace = TRUE)
+    options('affirm.id_cols' = "car")
+    affirm_true(
+      mtcars_modified,
+      label = "No. cylinders must be 4 or 6",
+      condition = cyl %in% c(4, 6),
+      id = 1,
+      data_frames = "mtcars"
+    )
+    affirm_true(
+      mtcars_modified,
+      label = "mpg lt 33",
+      id = 2,
+      condition = mpg < 33,
+      data_frames = "mtcars"
+    );
+    affirm_report_excel(file = tempfile(fileext = ".xlsx"), sheet_name = "{data_frames} {id} {total_n}")},
+    NA
+  )
 
   expect_error({
     affirm_init(replace = TRUE)

--- a/tests/testthat/test-affirm_report.R
+++ b/tests/testthat/test-affirm_report.R
@@ -144,8 +144,8 @@ test_that("affirm_report_excel() details", {
   },
   "`sheet_name` glue syntax expects one of"
   )
+})
 
-  
 test_that("affirmations with zero errors carried forward", {
 
   expect_error({
@@ -176,3 +176,4 @@ test_that("affirmations with zero errors carried forward", {
   )
 
 })
+

--- a/tests/testthat/test-affirm_report.R
+++ b/tests/testthat/test-affirm_report.R
@@ -113,7 +113,9 @@ test_that("affirm_report_excel() details", {
       condition = mpg < 33,
       data_frames = "mtcars"
     );
-    affirm_report_excel(file = tempfile(fileext = ".xlsx"), sheet_name = "{data_frames} {id} {total_n}")},
+    tmp_xlsx <- tempfile(fileext = ".xlsx")
+    affirm_report_excel(file = tmp_xlsx, sheet_name = "{data_frames} {id} {total_n}")
+    openxlsx::read.xlsx(tmp_xlsx, sheet = "mtcars 1 32")},
     NA
   )
 

--- a/tests/testthat/test-affirm_report.R
+++ b/tests/testthat/test-affirm_report.R
@@ -1,4 +1,5 @@
 test_that("affirm_report() works", {
+
   expect_error({
     affirm_init(replace = TRUE)
     affirm_not_na(
@@ -36,8 +37,8 @@ test_that("affirm_report() works", {
       label = "leave it all, no actions",
       condition = mpg > 33
     )
-    affirm_report_raw_data(variable_labels = TRUE)$data}
-  )
+    affirm_report_raw_data(variable_labels = TRUE)$data
+  })
 })
 
 
@@ -60,5 +61,67 @@ test_that("affirm_report() works, but skip in CI", {
     );
     affirm_report_gt() |> save_affirm_report_gt_png()},
     "affirm_report.png"
+  )
+})
+
+
+
+test_that("affirm_report_excel() details", {
+
+  mtcars_modified <- mtcars |>
+    tibble::rownames_to_column(var = "car")
+
+  attr(mtcars_modified$car, 'label') <- "Car model"
+  attr(mtcars_modified$mpg, 'label') <- "Miles/(US) gallon"
+  attr(mtcars_modified$cyl, 'label') <- "Number of cylinders"
+  attr(mtcars_modified$disp, 'label') <- "Displacement (cu.in.)"
+
+expect_error({
+  affirm_init(replace = TRUE)
+  options('affirm.id_cols' = "car")
+  affirm_true(
+    mtcars_modified,
+    label = "No. cylinders must be 4 or 6",
+    condition = cyl %in% c(4, 6),
+    id = 1,
+    data_frames = "mtcars"
+  )
+  affirm_true(
+    mtcars_modified,
+    label = "mpg lt 33",
+    id = 2,
+    condition = mpg < 33,
+    data_frames = "mtcars"
+  );
+  affirm_report_excel(file = tempfile(fileext = ".xlsx"))},
+  NA
+)
+
+  expect_error({
+    affirm_init(replace = TRUE)
+    affirm_true(
+      mtcars_modified,
+      label = "No. cylinders must be 4 or 6",
+      condition = cyl %in% c(4, 6),
+      id = 1,
+      data_frames = "mtcars"
+    )
+    affirm_report_excel(file = tempfile(fileext = ".xlsx"), sheet_name = "{data_frames}{id}{label}moooooooorreeeeecharacters")
+    },
+    "At least one sheet name exceeds the allowed 31 characters."
+  )
+
+  expect_error({
+    affirm_init(replace = TRUE)
+    affirm_true(
+      mtcars_modified,
+      label = "No. cylinders must be 4 or 6",
+      condition = cyl %in% c(4, 6),
+      id = 1,
+      data_frames = "mtcars"
+    )
+    affirm_report_excel(file = tempfile(fileext = ".xlsx"), sheet_name = "{data.frames}{id}")
+  },
+  "`sheet_name` glue syntax expects one of"
   )
 })


### PR DESCRIPTION
Closes #27 

What do you think of this so far? I think I might move this derivation to `affirm_report_raw_data` instead in another PR for creating custom excel reports, but I didn't want the PR to get too big and wanted some initial feedback on this.

Thanks!