### PR TITLE
return data frame of zero rows when no error found instead of `NULL`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # affirm (development version)
 
+* When no errors are found, return a data frame of zero rows instead of `NULL`.
+
 * No longer re-exporting `tibble()`, `as_tibble()`, `filter()`, `select()`, and `mutate()` from {dplyr}.
 
 * Added `affirm_clean_join()` function to check column names don't end in `".x"` or `".y"`.

--- a/R/utils.R
+++ b/R/utils.R
@@ -22,7 +22,7 @@
     dplyr::bind_rows(
       dplyr::tibble(
         ...,
-        data = switch(nrow(data) > 0L, data) |>  list()
+        data = list(data)
       )
     )
 

--- a/tests/testthat/_snaps/affirm_range.md
+++ b/tests/testthat/_snaps/affirm_range.md
@@ -305,6 +305,7 @@
       1 2000-01-01
       
       [[2]]
-      NULL
+      [1] x
+      <0 rows> (or 0-length row.names)
       
 

--- a/tests/testthat/test-affirm_report.R
+++ b/tests/testthat/test-affirm_report.R
@@ -62,3 +62,35 @@ test_that("affirm_report() works, but skip in CI", {
     "affirm_report.png"
   )
 })
+
+
+test_that("affirmations with zero errors carried forward", {
+
+  expect_error({
+    affirm_init(replace = TRUE)
+    affirm_true(
+      mtcars,
+      label = "No. cylinders must be 4, 6, or 8",
+      condition = cyl %in% c(4, 6, 8),
+      id = 1,
+      data_frames = "mtcars"
+    )
+    affirm_report_raw_data()},
+    NA
+  )
+
+  expect_s3_class({
+    affirm_init(replace = TRUE)
+    affirm_true(
+      mtcars,
+      label = "No. cylinders must be 4, 6, or 8",
+      condition = cyl %in% c(4, 6, 8),
+      id = 1,
+      data_frames = "mtcars"
+    )
+    affirm_report_raw_data()[["data"]][[1]]
+    },
+    "data.frame"
+  )
+
+})


### PR DESCRIPTION
Closes #28 